### PR TITLE
Merge multi-threaded rewrite into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/**
 device.conf
 cleanup.sh
+names.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/**
 device.conf
+cleanup.sh

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ echo "Creating udev rule..."
 
 # 1038 is, from what I can tell, the SteelSeries vendor ID
 sudo tee /etc/udev/rules.d/99-linuxmix.rules > /dev/null <<EOF
-KERNEL=="hidraw*", ATTRS{idVendor}=="$ss_vendor_id", MODE="0640", GROUP="$USER"
+KERNEL=="hidraw*", ATTRS{idVendor}=="$ss_vendor_id", MODE="0640", GROUP="audio"
 EOF
 
 if ! command -v pactl &> /dev/null; then
@@ -53,9 +53,6 @@ WorkingDirectory=/home/$USER/.config/linuxmix
 [Install]
 WantedBy=default.target
 EOF
-
-echo "Generating service configuration directory /home/$USER/.config/linuxmix/"
-mkdir ~/.config/linuxmix
 
 echo "Starting service..."
 systemctl --user daemon-reload

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn cleanup_sinks() {
     Command::new("pactl")
         .arg("unload-module")
         .arg("module-loopback")
-        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .unwrap()
         .wait()

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,232 +2,45 @@ use std::{
     fs::{File, OpenOptions},
     io::Read,
     process::{Command, Stdio},
+    sync::Mutex,
     thread, time,
 };
 
-const CHATMIX_CODE: u8 = 69;
-const HEADSET_POWER: u8 = 185;
+const CHATMIX_CODE: u8 = 69;        // Opcode for chatmix signal
+const HEADSET_POWER: u8 = 185;      // Opcode for power
 const GAME: &str = "Game";
 const CHAT: &str = "Chat";
 
-enum State {
-    Running,
-    Paused,
-    Waiting,
-}
-
-#[derive(PartialEq, Eq)]
-enum StreamState {
-    Continue,
-    Invalid,
-    Break,
-}
-
-fn main() {
-    let read_bytes = |stream: &mut File, uninitiated: bool| {
-        let mut bytes = [0u8; 4];
-        stream.read_exact(&mut bytes).unwrap();
-        process_bytes(bytes, uninitiated)
-    };
-
-    let mut stream = loop {
-        let mut dev_name = None;
-        let opt_stream = if let Ok(device) = std::fs::read_to_string("device.conf") {
-            dev_name = Some(device.clone());
-            OpenOptions::new()
-                .read(true)
-                .open(format!("/dev/{device}"))
-                .ok()
-                .or(determine_device(&mut dev_name))
-        } else {
-            determine_device(&mut dev_name)
-        };
-
-        let Some(mut _stream) = opt_stream else {
-            eprintln!("Did not receive ChatMix dial signal. Retrying...");
-            thread::sleep(time::Duration::from_secs(2));
-            continue;
-        };
-
-        // Confirm whether or not the file read is valid
-        // This will confirm if it is reading the correct file, as sometimes one of the three SteelSeries HIDRAW devices
-        // can transmit data, leading to the service continuing without properly using the correct HIDRAW device
-        let stat = read_bytes(&mut _stream, true);
-        if stat != StreamState::Invalid {
-            eprintln!("Reading from device {dev_name:?}");
-            break _stream;
-        }
-    };
-
-    let mut state = State::Waiting;
-
-    loop {
-        match state {
-            State::Running => {
-                loop {
-                    let stat = read_bytes(&mut stream, false);
-                    if stat == StreamState::Break {
-                        break;
-                    }
-                }
-                cleanup_sinks();
-                state = State::Paused;
-            }
-            State::Paused => {
-                let mut bytes = [0u8; 4];
-                stream.read_exact(&mut bytes).unwrap();
-                if bytes[0] == 185 && bytes[1] == 3 {
-                    configure_device();
-                    state = State::Running;
-                }
-            }
-            State::Waiting => {
-                configure_device();
-                state = State::Running;
-            }
-        }
-    }
-}
-
-fn determine_device(dev_name: &mut Option<String>) -> Option<File> {
-    // Putting this here so its viewable with systemctl status
-    println!(
-        "Mess around with the chatmix dial so the service can determine the correct file to read from!"
-    );
-
-    let mut devices = std::fs::read_dir("/dev/").unwrap().filter_map(|f| {
-        let t = f.unwrap().file_name().into_string().unwrap();
-        if t.starts_with("hidraw") {
-            let dev = OpenOptions::new()
-                .read(true)
-                .open(format!("/dev/{t}"))
-                .ok()?;
-            Some((dev, t))
-        } else {
-            None
-        }
-    });
-
-    let now = time::Instant::now();
-    let timeout = time::Duration::from_secs(10);
-
-    let (determined_device, hidraw_name) = 'device_loop: loop {
-        if now.elapsed() < timeout {
-            for (mut dev, name) in &mut devices {
-                let mut buf = [0u8; 4];
-                if let Ok(4) = dev.read(&mut buf) {
-                    if let [CHATMIX_CODE, _, _, 0] = buf {
-                        break 'device_loop (dev, name);
-                    }
-                }
-            }
-        } else {
-            return None;
-        }
-    };
-
-    std::fs::write("device.conf", hidraw_name.clone()).unwrap();
-
-    *dev_name = Some(hidraw_name);
-    Some(determined_device)
-}
-
-fn configure_device() {
-    // Prevent creating duplicate sinks, which would otherwise happen if the service is abruptly restarted
-    cleanup_sinks();
-
-    let default_sink = {
-        let default_sink_name = loop {
-            let def_sink_out = Command::new("pactl")
-                .arg("get-default-sink")
-                .output()
-                .unwrap()
-                .stdout;
-
-            if !def_sink_out.is_empty() {
-                break def_sink_out;
-            }
-
-            thread::sleep(time::Duration::from_secs(1));
-        };
-
-        get_device_id(&String::from_utf8(default_sink_name).unwrap().trim())
-    };
-
-    // Create Game sink
-    Command::new("pactl")
-        .arg("load-module")
-        .arg("module-null-sink")
-        .arg(format!("sink_name={}", GAME))
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap();
-
-    // Create Chat sink
-    Command::new("pactl")
-        .arg("load-module")
-        .arg("module-null-sink")
-        .arg(format!("sink_name={}", CHAT))
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap();
-
-    // Combine them, then loop it to the headphones
-    Command::new("pactl")
-        .arg("load-module")
-        .arg("module-loopback")
-        .arg(format!("source={CHAT}.monitor"))
-        .arg(format!("sink={default_sink}"))
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap();
-
-    Command::new("pactl")
-        .arg("load-module")
-        .arg("module-loopback")
-        .arg(format!("source={GAME}.monitor"))
-        .arg(format!("sink={default_sink}"))
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap();
-}
-
-fn process_bytes([code, game_vol, chat_vol, _]: [u8; 4], uninitiated: bool) -> StreamState {
-    let set_volume = |channel: &str, vol: u8| {
-        Command::new("pactl")
-            .arg("set-sink-volume")
-            .arg(format!("{}", channel))
-            .arg(format!("{}%", vol))
-            .spawn()
-            .unwrap();
-    };
-
-    match code {
-        // 69 is for volume wheel values
-        CHATMIX_CODE => {
-            set_volume(GAME, game_vol);
-            set_volume(CHAT, chat_vol)
-        }
-        HEADSET_POWER if game_vol == 2 => {
-            //power_off
-            return StreamState::Break;
-        }
-        _ if uninitiated => {
-            return StreamState::Invalid;
-        }
-        _ => {} // Do nothing if otherwise
+fn main() -> ! {
+    let devices = get_devices();
+    let mut threads = vec![];
+    for device in devices {
+        threads.push(thread::spawn(|| read_device(device)));
     }
 
-    Command::new("pactl")
-        .arg("set-default-sink")
-        .arg("Game")
-        .spawn()
-        .unwrap();
-    return StreamState::Continue;
+    while threads.iter().any(|f| !f.is_finished()) {
+        thread::sleep(time::Duration::from_millis(100));
+    }
+
+    panic!("All threads exited unexpectedly");
+}
+
+fn get_devices() -> Vec<File> {
+    std::fs::read_dir("/dev/")
+        .unwrap()
+        .filter_map(|f| {
+            let t = f.unwrap().file_name().into_string().unwrap();
+            if t.starts_with("hidraw") {
+                if let Ok(dev) = OpenOptions::new().read(true).open(format!("/dev/{t}")) {
+                    Some(dev)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<File>>()
 }
 
 fn get_device_id(device_name: &str) -> u32 {
@@ -256,10 +69,122 @@ fn get_device_id(device_name: &str) -> u32 {
         .unwrap()
 }
 
+fn configure_sinks() {
+    // Prevent creating duplicate sinks, which would otherwise happen if the service is abruptly restarted
+    cleanup_sinks();
+
+    let default_sink = {
+        let default_sink_name = loop {
+            let def_sink_out = Command::new("pactl")
+                .arg("get-default-sink")
+                .output()
+                .unwrap()
+                .stdout;
+
+            if !def_sink_out.is_empty() {
+                break def_sink_out;
+            }
+
+            thread::sleep(time::Duration::from_secs(1));
+        };
+
+        get_device_id(&String::from_utf8(default_sink_name).unwrap().trim())
+    };
+
+    let load_null_sink = |sink_name: &str| {
+        Command::new("pactl")
+            .arg("load-module")
+            .arg("module-null-sink")
+            .arg(format!("sink_name={sink_name}"))
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap();
+    };
+
+    let load_loopback = |source: &str| {
+        Command::new("pactl")
+            .arg("load-module")
+            .arg("module-loopback")
+            .arg(format!("source={source}.monitor"))
+            .arg(format!("sink={default_sink}"))
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap();
+    };
+
+    load_null_sink(GAME);
+    load_null_sink(CHAT);
+
+    load_loopback(GAME);
+    load_loopback(CHAT);
+}
+
+fn read_device(mut file: File) {
+    let mut buf = [8u8; 4];
+    while let Ok(()) = file.read_exact(&mut buf) {
+        process_bytes(buf);
+    }
+}
+
+fn process_bytes([code, game_vol, chat_vol, _]: [u8; 4]) {
+    static IS_CONF: Mutex<bool> = Mutex::new(false);
+
+    let set_volume = |channel: &str, vol: u8| {
+        Command::new("pactl")
+            .arg("set-sink-volume")
+            .arg(format!("{}", channel))
+            .arg(format!("{}%", vol))
+            .spawn()
+            .unwrap();
+    };
+
+    match code {
+        CHATMIX_CODE => {
+            if let Ok(mut conf) = IS_CONF.lock()
+                && !*conf
+            {
+                configure_sinks();
+                *conf = true;
+            }
+            set_volume(GAME, game_vol);
+            set_volume(CHAT, chat_vol)
+        }
+        HEADSET_POWER if game_vol == 2 => {
+            // Power off
+            if let Ok(mut conf) = IS_CONF.lock()
+                && *conf
+            {
+                cleanup_sinks();
+                *conf = false;
+            }
+            return; // Return early bc we dont want to set the default sink to anything
+        }
+        HEADSET_POWER if game_vol == 3 => {
+            // Power on
+            if let Ok(mut conf) = IS_CONF.lock()
+                && !*conf
+            {
+                configure_sinks();
+                *conf = true;
+            }
+        }
+        _ => return, // Do nothing if otherwise
+    }
+
+    Command::new("pactl")
+        .arg("set-default-sink")
+        .arg("Game")
+        .spawn()
+        .unwrap();
+}
+
 fn cleanup_sinks() {
     Command::new("pactl")
         .arg("unload-module")
         .arg("module-loopback")
+        .stdout(Stdio::null())
         .spawn()
         .unwrap()
         .wait()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+linuxmix_user_name=linuxmix
+
 echo "Stopping service..."
 systemctl --user stop linuxmix
 
@@ -8,6 +10,7 @@ pactl unload-module module-loopback
 pw-cli destroy Game
 pw-cli destroy Chat
 
+# Removing linuxmix udev rules and reloading udevadm
 echo "Removing udev rule..."
 sudo rm /etc/udev/rules.d/99-linuxmix.rules
 


### PR DESCRIPTION
Rewrites how the service reads from devices to use a multi-threaded approach, preventing the service from locking up in the event it cannot read from one file, or if it takes too long to read from a file. 

There are three devices used by the headset, but only one corresponds to the ChatMix dial. Only way to know which one is which is to read from them, looking for properly-formatted data. The new approach has the service reading from all of them at once, only acting when receiving properly-formatted data.

This merge also updates the udev rules generated to use system groups instead of the active user, improving security and complying with recent systemd changes.